### PR TITLE
Redirecionando para link real

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,6 +13,12 @@
     </header>
 
     <article class="content-po-ex">
+		{% if page.link %}
+			Esse post está em outro lugar, <a href="{{ page.link }}" title="{{ page.link }}">clique aqui</a> ou espere alguns segundos para ser redirecionado.
+			<script type="text/javascript">
+				window.location.replace("{{ page.link }}");
+			</script>
+		{% endif %}
     	{{ content }}
       <span class="edit"><a href="{{ page.edit }}" target="_blank" ><i class="fa fa-github fa-2x"></i> Editar esse post</a></span>
     </article>

--- a/_posts/2015-12-15-relato-projeto-open-source.markdown
+++ b/_posts/2015-12-15-relato-projeto-open-source.markdown
@@ -5,5 +5,5 @@ published:   15-12-2015
 categories: blog
 description: Estudos em cenários reais, ajudando o próximo, desfrutando do open source.
 image:   "/assets/imagem/artigo-relato.jpeg"
-url: https://medium.com/@andersoonfront/relato-de-uma-projeto-open-source-925ab40098e8#.473fhllng
+link: https://medium.com/@andersoonfront/relato-de-uma-projeto-open-source-925ab40098e8#.473fhllng
 ---

--- a/_posts/2016-02-27-tentando-corrigir-minhas-deficiencias.markdown
+++ b/_posts/2016-02-27-tentando-corrigir-minhas-deficiencias.markdown
@@ -5,5 +5,5 @@ published:   27-02-2016
 categories: blog
 description:  Desde lá já li centenas de artigos, sem contar alguns que leio no médium que não coloco lá...
 image:   "/assets/imagem/corrigir-deficiencias.jpeg"
-url: https://medium.com/@andersoonfront/tentando-corrigir-minhas-defici%C3%AAncias-9138ee858850#.kccgkgrsd
+link: https://medium.com/@andersoonfront/tentando-corrigir-minhas-defici%C3%AAncias-9138ee858850#.kccgkgrsd
 ---


### PR DESCRIPTION
**Problema**: Hoje a variável utilizada é `url` para colocar o link do medium.com (onde o post realmente está), o que confunde o jekyll ao, por exemplo, criar o feed.xml.

**Solução**: Mudei o nome da variável para `link` e adicionei um redirecionamento nas páginas caso essa variável esteja presente.
